### PR TITLE
feat: add initial linting workflow

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,6 @@
+[flake8]
+max-line-length = 80
+max-complexity = 11
+per-file-ignores = __init__.py:F401
+extend-ignore = E501
+extend-select = B9

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,8 +23,8 @@ jobs:
       - name: Install flake8
         run: pip install flake8 flake8-bugbear
       - name: Run flake8
-        run: flake8 --verbose --exit-zero --config ./.flake8 .
+        run: flake8 --verbose --exit-zero --config ${{ vars.GITHUB_WORKSPACE }}/.flake8 ${{ vars.GITHUB_WORKSPACE }}
       - name: Install nbqa
         run: pip install nbqa
       - name: Run nbqa
-        run: nbqa flake8 --verbose --exit-zero --config ./.flake8 .
+        run: nbqa flake8 --verbose --exit-zero --config ${{ vars.GITHUB_WORKSPACE }}/.flake8 ${{ vars.GITHUB_WORKSPACE }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9.13
+          python-version: 3.11.2
           architecture: x64
       - name: Install flake8
         run: pip install flake8==4.0.1 flake8-bugbear

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.11.2
           architecture: x64

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -22,9 +22,11 @@ jobs:
           architecture: x64
       - name: Install flake8
         run: pip install flake8 flake8-bugbear
+      - name: List current directory
+        run: ls -alh $GITHUB_WORKSPACE
       - name: Run flake8
-        run: flake8 --verbose --exit-zero --config ${{ vars.GITHUB_WORKSPACE }}/.flake8 ${{ vars.GITHUB_WORKSPACE }}
+        run: flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8
       - name: Install nbqa
         run: pip install nbqa
       - name: Run nbqa
-        run: nbqa flake8 --verbose --exit-zero --config ${{ vars.GITHUB_WORKSPACE }}/.flake8 ${{ vars.GITHUB_WORKSPACE }}
+        run: nbqa flake8 --verbose --exit-zero --config vars.GITHUB_WORKSPACE/.flake8 $GITHUB_WORKSPACE

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,7 +21,7 @@ jobs:
           python-version: 3.11.2
           architecture: x64
       - name: Install flake8
-        run: pip install flake8 flake8-bugbear
+        run: pip install flake8 flake8-bugbear flake8-docstrings
       - name: Run flake8
         run: flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8
       - name: Install nbqa

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,6 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          src: $GITHUB_WORKSPACE
           jupyter: true
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,6 +15,7 @@ jobs:
   linting:
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v3
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -22,11 +23,9 @@ jobs:
           architecture: x64
       - name: Install flake8
         run: pip install flake8 flake8-bugbear
-      - name: List current directory
-        run: ls -alh $GITHUB_WORKSPACE
       - name: Run flake8
         run: flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8
       - name: Install nbqa
         run: pip install nbqa
       - name: Run nbqa
-        run: nbqa flake8 --verbose --exit-zero --config vars.GITHUB_WORKSPACE/.flake8 $GITHUB_WORKSPACE
+        run: nbqa flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8 $GITHUB_WORKSPACE

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: psf/black@stable
         with:
           options: "--check --verbose"
-          src: "./"
+          src: $GITHUB_WORKSPACE
           jupyter: true
   linting:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -3,7 +3,7 @@ name: lint
 on: [pull_request]
 
 jobs:
-  black:
+  check_formatting:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -12,7 +12,7 @@ jobs:
           options: "--check --verbose"
           src: "./"
           jupyter: true
-  flake8:
+  linting:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Python
@@ -21,6 +21,10 @@ jobs:
           python-version: 3.11.2
           architecture: x64
       - name: Install flake8
-        run: pip install flake8==4.0.1 flake8-bugbear
+        run: pip install flake8 flake8-bugbear
       - name: Run flake8
-        run: flake8 --verbose --exit-zero --config ./.flake8
+        run: flake8 --verbose --exit-zero --config ./.flake8 .
+      - name: Install nbqa
+        run: pip install nbqa
+      - name: Run nbqa
+        run: nbqa flake8 --verbose --exit-zero --config ./.flake8 .

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -21,10 +21,10 @@ jobs:
           python-version: 3.11.2
           architecture: x64
       - name: Install flake8
-        run: pip install flake8 flake8-bugbear flake8-docstrings
+        run: python3.11 -m pip install flake8 flake8-bugbear flake8-docstrings
       - name: Run flake8
         run: flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8
       - name: Install nbqa
-        run: pip install nbqa
+        run: python3.11 -m pip install nbqa
       - name: Run nbqa
         run: nbqa flake8 --verbose --exit-zero --config $GITHUB_WORKSPACE/.flake8 $GITHUB_WORKSPACE

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,26 @@
+name: lint
+
+on: [pull_request]
+
+jobs:
+  black:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: psf/black@stable
+        with:
+          options: "--check --verbose"
+          src: "./"
+          jupyter: true
+  flake8:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Setup Python
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.9.13
+          architecture: x64
+      - name: Install flake8
+        run: pip install flake8==4.0.1 flake8-bugbear
+      - name: Run flake8
+        run: flake8 --verbose --exit-zero --config ./.flake8


### PR DESCRIPTION
I've included my own `.flake8` config file along with this -- we can change or remove it as necessary.

In addition to `black` format checking, this action also uses `flake8` and [`flake8-bugbear`](https://github.com/PyCQA/flake8-bugbear) style checking.

This is the [`pycodestyle` error list](https://pycodestyle.pycqa.org/en/latest/intro.html#error-codes), the changes we're making below are:
- ignoring blank `__init__.py` files
- Ignoring the 80-char line length warning, in favor of
- Taking all `flake8-bugbear` warnings, particularly [B950](https://github.com/PyCQA/flake8-bugbear#opinionated-warnings)